### PR TITLE
Small correction to Viterbi Algorithm

### DIFF
--- a/mmk1.tex
+++ b/mmk1.tex
@@ -606,8 +606,8 @@ Berechnet die Beobachtungswahscheinlichkeit des wahrscheinlichsten Pfades.
 		$\psi_t(j) = \underset{1 \leq i \leq N}{\operatorname{argmax}} \left[\delta_{t-1}(i) a_{ij} \right]$\\
 		$2 \leq t \leq T; \quad 1 \leq j \leq N$\\
 	\item Terminierung: \\
-		$P^* = \max\limits_{1 \leq i \leq N} [\delta_t(i)]$\\
-		$q_T^* = \max\limits_{1 \leq i \leq N} [\delta_t(i)]$\\
+		$P^* = \max\limits_{1 \leq i \leq N} [\delta_T(i)]$\\
+		$q_T^* = \max\limits_{1 \leq i \leq N} [\delta_T(i)]$\\
 	\item Ermittlung der wahrsch. Zustandsfolge:\\
 		$q_t^* = \psi_{t+1}(q^*_{t+1})$\\
 		$t= T-1, T-2, \dots , 1$\\


### PR DESCRIPTION
Third step of Viterbi's algorithm (Terminierung) was using lowercase 't' as the subscript, while the original formula has the uppercase 'T' (equation 5.38 in the book, page 136).